### PR TITLE
Disable haproxy in ocata and beyond

### DIFF
--- a/charmhelpers/contrib/openstack/ha/utils.py
+++ b/charmhelpers/contrib/openstack/ha/utils.py
@@ -127,7 +127,9 @@ def expect_ha():
     return len(ha_related_units) > 0 or config('vip') or config('dns-ha')
 
 
-def generate_ha_relation_data(service, extra_settings=None):
+def generate_ha_relation_data(service,
+                              extra_settings=None,
+                              haproxy_enabled=True):
     """ Generate relation data for ha relation
 
     Based on configuration options and unit interfaces, generate a json
@@ -152,21 +154,18 @@ def generate_ha_relation_data(service, extra_settings=None):
     @param extra_settings: Dict of additional resource data
     @returns dict: json encoded data for use with relation_set
     """
-    _haproxy_res = 'res_{}_haproxy'.format(service)
-    _relation_data = {
-        'resources': {
-            _haproxy_res: 'lsb:haproxy',
-        },
-        'resource_params': {
+    _relation_data = {'resources': {}, 'resource_params': {}}
+
+    if haproxy_enabled:
+        _haproxy_res = 'res_{}_haproxy'.format(service)
+        _relation_data['resources'] = {_haproxy_res: 'lsb:haproxy'}
+        _relation_data['resource_params'] = {
             _haproxy_res: 'op monitor interval="5s"'
-        },
-        'init_services': {
-            _haproxy_res: 'haproxy'
-        },
-        'clones': {
+        }
+        _relation_data['init_services'] = {_haproxy_res: 'haproxy'}
+        _relation_data['clones'] = {
             'cl_{}_haproxy'.format(service): _haproxy_res
-        },
-    }
+        }
 
     if extra_settings:
         for k, v in extra_settings.items():

--- a/hooks/ceilometer_hooks.py
+++ b/hooks/ceilometer_hooks.py
@@ -330,8 +330,17 @@ def ha_joined(relation_id=None):
             'res_ceilometer_agent_central': 'op monitor interval="30s"'},
         'delete_resources': ['res_ceilometer_polling'],
     }
+
+    haproxy_enabled = True
+    cmp_codename = CompareOpenStackReleases(
+        get_os_codename_install_source(config('openstack-origin')))
+    if cmp_codename >= 'ocata':
+        haproxy_enabled = False
+        ceil_ha_settings['delete_resources'].append('res_ceilometer_haproxy')
+
     settings = generate_ha_relation_data(
         'ceilometer',
+        haproxy_enabled=haproxy_enabled,
         extra_settings=ceil_ha_settings)
     relation_set(relation_id=relation_id, **settings)
 


### PR DESCRIPTION
Also take care to remove haproxy in case of upgrades.

NOTE: This is a backport of a feature planned for release in stable/19.07.

Change-Id: I9dfdfc366fb64e50f0209e85072f66998a69f0ac
Closes-Bug: #1773894